### PR TITLE
Bump version of nbgitpuller & jupyterhub only

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,12 +23,12 @@ dask-gateway==0.9.0
 # Infrastructure things
 jupyterlab==3.*
 voila==0.2.6
-nbgitpuller==0.10.*
+nbgitpuller==1.1.*
 jupyter-resource-usage==0.5.0
 RISE==5.7.1
 jupyter_contrib_nbextensions==0.5.1
 notebook==6.1.4
-jupyterhub==2.3.1
+jupyterhub==3.*
 jupyter-rsession-proxy==1.2
 jupyter-tree-download==1.0.1
 ipywidgets==7.5.1


### PR DESCRIPTION
Fall-out from https://github.com/2i2c-org/infrastructure/pull/2160